### PR TITLE
Click on sample code to select active color

### DIFF
--- a/app/assets/javascripts/classes/swatch.js.es6
+++ b/app/assets/javascripts/classes/swatch.js.es6
@@ -10,13 +10,12 @@ class Swatch {
 
     $(this.swatch).find(".color").on("click", function(e) {
       var newColor = e.target.attributes["data-color"].value;
+      this.setColorToActive(newColor);
+    }.bind(this));
 
-      if(this.activeColor != newColor) {
-        $(".active").removeClass("active");
-        $(e.target).addClass("active");
-
-        this.activeColor = newColor;
-      }
+    $(this.preview).find("span").on("click", function(e) {
+      var newColor = e.target.classList[0].replace("fg-", "");
+      this.setColorToActive(newColor);
     }.bind(this));
   }
 
@@ -39,6 +38,16 @@ class Swatch {
   }
 
   // private API
+
+  setColorToActive(colorCode) {
+    if(this.activeColor != colorCode) {
+      $(this.swatch).find(".active").removeClass("active");
+      $(this.swatch).find("[data-color='" + colorCode + "']").addClass("active");
+
+      this.activeColor = colorCode;
+    }
+  }
+
   updateColor(colorCode, color) {
     var bgColorClass = ".bg-" + colorCode;
     var fgColorClass = ".fg-" + colorCode;

--- a/app/assets/stylesheets/components/_colors.scss
+++ b/app/assets/stylesheets/components/_colors.scss
@@ -23,6 +23,7 @@ $color-column-height: $color-row-count * $color-size + ($color-row-count - 1) * 
   height: $color-size;
   margin-bottom: $base-spacing;
   width: $color-size;
+  cursor: pointer;
 
   &:nth-child(8n) {
     margin-bottom: 0;
@@ -31,4 +32,8 @@ $color-column-height: $color-row-count * $color-size + ($color-row-count - 1) * 
   &.active {
     border: 6px solid black;
   }
+}
+
+.preview span {
+  cursor: pointer;
 }


### PR DESCRIPTION
Closes #6 
## Problem

If the user wants to change a color in the interface, they need to look it
up in the color palette to activate it.
## Solution
- Let the user click directly on the text in the preview to select a color to change.
- Indicate clickable elements with a pointer cursor
