### PR TITLE
Add a native color picker

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,7 +41,7 @@ if(window.location.hash) {
   var colors = window.location.hash.replace("#", "").split(",");
 }
 
-var palette = new Palette($(".palette")[0]);
+var palette = new Palette($(".palette canvas")[0], $(".color_picker")[0]);
 var swatch = new Swatch($(".colors")[0], $(".preview")[0]);
 
 palette.draw();

--- a/app/assets/javascripts/classes/palette.js.es6
+++ b/app/assets/javascripts/classes/palette.js.es6
@@ -1,11 +1,12 @@
 "use strict";
 
 class Palette {
-  constructor(canvas) {
+  constructor(canvas, color_picker) {
     this.canvas = canvas;
+    this.color_picker = color_picker;
     this.saturation = 0.5;
 
-    this.canvas.addEventListener('mousewheel', this.updateSaturation.bind(this));
+    this.canvas.addEventListener("mousewheel", this.updateSaturation.bind(this));
   }
 
   updateSaturation(e) {
@@ -58,6 +59,10 @@ class Palette {
 
     $(this.canvas).on("mousemove", function(e){
       if(e.buttons) { this.sendSelection(e, callback); }
+    }.bind(this));
+
+    this.color_picker.addEventListener("change", function(e) {
+      callback(new ColorHex(e.target.value));
     }.bind(this));
   }
 

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -21,6 +21,20 @@
 .palette {
   flex: 1;
   margin-right: $base-spacing;
+
+  display: flex;
+  flex-direction: column;
+
+  canvas {
+    flex-grow: 1;
+    width: 100%;
+    margin-bottom: $base-spacing;
+  }
+
+  input {
+    flex-grow: 0;
+    height: $base-spacing * 2;
+  }
 }
 
 .actions {

--- a/app/views/colors/index.html.erb
+++ b/app/views/colors/index.html.erb
@@ -1,6 +1,8 @@
 <div class="selection">
-  <canvas class="palette" height="100" width="100">
-  </canvas>
+  <div class="palette">
+    <canvas></canvas>
+    <input type="color" class="color_picker" />
+  </div>
 
   <div class="colors">
     <% 16.times do |color| %>


### PR DESCRIPTION
Closes #7.
## Problem

Users are limited to selecting colors from the palette,
and cannot pull in colors from other tabs or apps on their screen.
## Solution

Add a native color input element,
which allows the user to choose colors with an eyedropper
from any other content on their screen.
