### PR TITLE
Display a warning for users on small screen sizes

### DIFF
--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -1,56 +1,90 @@
+$header-height: $base-spacing * 2;
+
 .content {
   display: flex;
-  height: 100vh;
   flex-direction: column;
   align-items: stretch;
 }
 
-.selection {
-  display: flex;
-  flex: 0 1 90vh;
-  margin: $base-spacing;
+.palette,
+.colors {
+  display: none;
+}
+
+.small-screen-warning {
+  padding: $base-spacing;
+  color: $medium-gray;
 }
 
 .preview {
-  flex: 0 1 50%;
-  margin: 0;
-  margin-left: $base-spacing;
   padding: $base-spacing;
 }
 
-.colors {
-  flex: 0 1 20%;
-}
-
-.palette {
-  flex: 0 1 50%;
-  margin-right: $base-spacing;
-
-  display: flex;
-  flex-direction: column;
-
-  canvas {
-    flex-grow: 1;
-    width: 100%;
-    margin-bottom: $base-spacing;
-  }
-
-  input {
-    flex-grow: 0;
-    height: $base-spacing * 2;
-    margin-bottom: 0;
-  }
-}
-
-.actions {
+.actions,
+.header {
   left: 0;
   right: 0;
-  flex: 0 0 $base-spacing * 2;
+  flex: 0 0 $header-height;
+  text-align: center;
+}
 
-  .download {
+h1 {
+  margin: $small-spacing 0;
+}
+
+.download {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
+}
+
+@include media($large-screen-up) {
+  .content {
+    height: 100vh;
+  }
+
+  .colors {
     display: block;
-    width: 100%;
-    height: 100%;
-    border-radius: 0;
+  }
+
+  .small-screen-warning {
+    display: none;
+  }
+
+  .selection {
+    display: flex;
+    flex: 0 1 90vh;
+    margin: $base-spacing;
+  }
+
+  .preview {
+    flex: 0 1 50%;
+    margin: 0;
+    margin-left: $base-spacing;
+  }
+
+  .colors {
+    flex: 0 1 20%;
+  }
+
+  .palette {
+    flex: 0 1 50%;
+    margin-right: $base-spacing;
+
+    display: flex;
+    flex-direction: column;
+
+    canvas {
+      flex-grow: 1;
+      width: 100%;
+      margin-bottom: $base-spacing;
+    }
+
+    input {
+      flex-grow: 0;
+      height: $base-spacing * 2;
+      margin-bottom: 0;
+    }
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,5 @@
 @import "base/base";
 @import "refills/flashes";
 
-@import "components/**/*";
-
 @import "layout";
+@import "components/**/*";

--- a/app/views/colors/index.html.erb
+++ b/app/views/colors/index.html.erb
@@ -1,3 +1,18 @@
+<div class="header">
+  <h1>colors.graysonwright.com</h1>
+
+  <span>
+    Download colorscheme files for your favorite text-based programs.
+  </span>
+</div>
+
+<div class="small-screen-warning">
+  Your device's screen is too small
+  for us to show all of the controls for this app.
+  For now, you can view and download the current colorscheme.
+  To modify the scheme, please view this site on a larger screen.
+</div>
+
 <div class="selection">
   <div class="palette">
     <canvas></canvas>
@@ -38,14 +53,11 @@
 </div>
 
 <div class="actions">
-<!-- options for editor types -
+<!-- options for which config files to download -
   command line
   sublime text
   vim (neovim?)
   emacs
-
-  # can use the chriskempson/base16 project
-  # as a basis for generating different color configuration files
 -->
   <button class="download">Download</button>
 </div>


### PR DESCRIPTION
## Problem

On small screens, the applications' controls
are too small to use effectively.
## Solution

Don't display the controls for modifying the colorscheme
unless the user's screen size is adequate.
Instead, display a message
prompting the user to switch to a larger screen.
